### PR TITLE
Make volume_tags optional and allow to set them directly on root device

### DIFF
--- a/input.tf
+++ b/input.tf
@@ -138,7 +138,7 @@ variable "tags" {
 
 variable "volume_tags" {
   type    = map(string)
-  default = {}
+  default = null
 }
 
 variable "vpc_security_group_ids" {

--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,7 @@ resource "aws_instance" "ec2_instance" {
       kms_key_id            = lookup(root_block_device.value, "kms_key_id", null)
       volume_size           = lookup(root_block_device.value, "volume_size", null)
       volume_type           = lookup(root_block_device.value, "volume_type", null)
+      tags                  = lookup(root_block_device.value, "tags", null) != null ? jsondecode(lookup(root_block_device.value, "tags")) : null
     }
   }
   source_dest_check      = length(var.network_interfaces) > 0 ? null : var.source_dest_check


### PR DESCRIPTION
These changes are required to allow adding additional volumes to the instance without getting weird conflicting tag configurations.

Note that the tags for the root device need to be specified as json string since map doesn't allow conflicting value types and object would require specifying all the value all the time.

Signed-off-by: Frank Lichtenheld <frank@lichtenheld.com>