### PR TITLE
Update deprecated TF template provider to templatefile

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -66,19 +66,6 @@ data "local_file" "write_scripts" {
   filename = "${path.module}/write-scripts.cfg"
 }
 
-# cloud-init config to run install-puppet.sh
-data "template_file" "run_scripts" {
-  template = file("${path.module}/run-scripts.cfg.tftpl")
-  vars     = {
-               hostname             = var.hostname,
-               deployment           = var.deployment,
-               install_puppet_agent = var.install_puppet_agent,
-               puppet_env           = local.puppet_env,
-               puppet_version       = var.puppet_version,
-               puppetmaster_ip      = var.puppetmaster_ip,
-             }
-}
-
 data "cloudinit_config" "provision" {
   gzip          = false
   base64_encode = true
@@ -99,7 +86,16 @@ data "cloudinit_config" "provision" {
   # adjust the parameters passed to the scripts.
   part {
     content_type = "text/cloud-config"
-    content      = data.template_file.run_scripts.rendered
+    content      = templatefile("${path.module}/run-scripts.cfg.tftpl",
+                                {
+                                  hostname             = var.hostname,
+                                  deployment           = var.deployment,
+                                  install_puppet_agent = var.install_puppet_agent,
+                                  puppet_env           = local.puppet_env,
+                                  puppet_version       = var.puppet_version,
+                                  puppetmaster_ip      = var.puppetmaster_ip,
+                                }
+                               )
   }
 }
 


### PR DESCRIPTION
The deprecated TF template provider is not supported by the new platforms
```
│ Error: Incompatible provider version
│ 
│ Provider registry.terraform.io/hashicorp/template v2.2.0 does not have a package available for your current platform, darwin_arm64.
```
Updated to `templatefile`

Tested rendered file - output is the same
```
file = <<EOT
#cloud-config
runcmd:
  - [ "/var/cache/set-hostname.sh", "qayd_hostname1" ]
  - [ "/var/cache/add-deployment-fact.sh", "qayd_deployment1" ]
  - [ "/var/cache/add-puppetmaster-to-etc-hosts.sh", "1.1.1.1" ]
  - [ "/var/cache/install-puppet.sh", "-n", "qayd_hostname1", "-e", "qayd_deployment1", "-p", "6", "-s"]
  - [ "rm", "-f", "/var/cache/set-hostname.sh", "/var/cache/add-puppetmaster-to-etc-hosts.sh", "/var/cache/add-deployment-fact.sh", "/var/cache/install-puppet.sh" ]

EOT
```

