### PR TITLE
output: Expose primary_network_interface_id

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -17,3 +17,6 @@ output "private_dns" {
   value = aws_instance.ec2_instance.*.private_dns
 }
 
+output "primary_network_interface_id" {
+  value = aws_instance.ec2_instance.*.primary_network_interface_id
+}


### PR DESCRIPTION
In version 5 of aws provider routes don't accept instance ids anymore. Instead you need specify the id of the network interface.