### PR TITLE
Add ipv6 output for AWS instances

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -13,6 +13,10 @@ output "public_ip" {
   value = aws_instance.ec2_instance.*.public_ip
 }
 
+output "ipv6_addresses" {
+  value = aws_instance.ec2_instance.*.ipv6_addresses
+}
+
 output "private_dns" {
   value = aws_instance.ec2_instance.*.private_dns
 }


### PR DESCRIPTION
added ipv6, it is commonly used with private and public ipv4