### PR TITLE
Do not force rebuild of the instance if AMI changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,6 +53,7 @@ resource "aws_instance" "ec2_instance" {
 
   lifecycle {
     ignore_changes = [
+      ami,
       associate_public_ip_address,
       ebs_optimized,
       user_data,


### PR DESCRIPTION
This is useful when getting the AMI ID using a data source filter for example.