### PR TITLE
Also add Ansible-compatible deployment fact

### DIFF
--- a/write-scripts.cfg
+++ b/write-scripts.cfg
@@ -53,10 +53,16 @@ write_files:
       fi
       
       export PATH=$PATH:/bin:/sbin:/usr/bin:/usr/sbin:/opt/puppetlabs/bin:/opt/puppetlabs/puppet/bin
-      
+
+      # Add Puppet fact (deployment)
       mkdir -p /etc/facter/facts.d
       chown -R root:root /etc/facter
       echo "deployment: ${DEPLOYMENT}" > /etc/facter/facts.d/deployment.yaml
+
+      # Add Ansible fact (deployment.name)
+      mkdir -p /etc/ansible/facts.d
+      chown -R root:root /etc/ansible/facts.d
+      echo "{ \"name\": \"${DEPLOYMENT}\" }" > /etc/ansible/facts.d/deployment.fact
   - path: /var/cache/install-puppet.sh
     owner: root:root
     permissions: '0755'


### PR DESCRIPTION
Having it available does not hurt even if the node is managed by Puppet.